### PR TITLE
Remoção do Optional no adapter de ListBy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.goapigo</groupId>
     <artifactId>goapigo-core</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <name>goapigo-core</name>
     <description>Core of GoApiGo</description>
 

--- a/src/main/java/com/goapigo/core/adapter/ListByAdapter.java
+++ b/src/main/java/com/goapigo/core/adapter/ListByAdapter.java
@@ -2,13 +2,14 @@ package com.goapigo.core.adapter;
 
 import com.goapigo.core.GoApiGoProcessor;
 import com.goapigo.core.annotations.ListBy;
+import lombok.RequiredArgsConstructor;
+import lombok.var;
+import org.jsoup.Jsoup;
+
 import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.var;
-import org.jsoup.Jsoup;
 
 @RequiredArgsConstructor
 public class ListByAdapter implements Adaptable<List<?>> {

--- a/src/main/java/com/goapigo/core/adapter/ListByAdapter.java
+++ b/src/main/java/com/goapigo/core/adapter/ListByAdapter.java
@@ -4,6 +4,7 @@ import com.goapigo.core.GoApiGoProcessor;
 import com.goapigo.core.annotations.ListBy;
 import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.var;
@@ -24,6 +25,8 @@ public class ListByAdapter implements Adaptable<List<?>> {
     var service = new GoApiGoProcessor();
     return elements.stream()
         .map(element -> service.processElement(element.html(), responseClass))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
         .collect(Collectors.toList());
   }
 }

--- a/src/test/java/com/goapigo/core/adapter/ListByAdapterTest.java
+++ b/src/test/java/com/goapigo/core/adapter/ListByAdapterTest.java
@@ -37,11 +37,11 @@ public class ListByAdapterTest {
     var annotation = elementsField.getAnnotation(ListBy.class);
     var adapter =
         new ListByAdapter(annotation, LIST_ELEMENTS_TEMPLATE, AdapterUtil.getType(elementsField));
-    var response = (List<Optional<String>>) adapter.adapt();
+    var response = (List<String>) adapter.adapt();
     assertThat(response).isNotNull().hasSize(3);
     assertSoftly(
         softAssertions ->
-            response.forEach(element -> softAssertions.assertThat(element).isPresent()));
+            response.forEach(element -> softAssertions.assertThat(element).isNotNull()));
   }
 
   @Test
@@ -51,10 +51,10 @@ public class ListByAdapterTest {
     var adapter =
         new ListByAdapter(
             annotation, LIST_ANOTHER_ELEMENTS_TEMPLATE, AdapterUtil.getType(anotherElementsField));
-    var response = (List<Optional<AdaptableElementClass>>) adapter.adapt();
+    var response = (List<AdaptableElementClass>) adapter.adapt();
     assertThat(response).isNotNull().hasSize(3);
     assertSoftly(
         softAssertions ->
-            response.forEach(element -> softAssertions.assertThat(element).isPresent()));
+            response.forEach(element -> softAssertions.assertThat(element).isNotNull()));
   }
 }

--- a/src/test/java/com/goapigo/core/adapter/ListByAdapterTest.java
+++ b/src/test/java/com/goapigo/core/adapter/ListByAdapterTest.java
@@ -1,18 +1,18 @@
 package com.goapigo.core.adapter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import com.goapigo.core.annotations.ListBy;
 import com.goapigo.core.dto.AdaptableClass;
 import com.goapigo.core.dto.AdaptableElementClass;
 import com.goapigo.core.util.AdapterUtil;
-import java.util.List;
-import java.util.Optional;
 import lombok.var;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ListByAdapterTest {


### PR DESCRIPTION
Ao mapear uma lista com o `ListBy`, estava sendo criada uma lista de `Optional<T>`, causando problemas ao iterar a lista usando `Stream`, por exemplo.